### PR TITLE
Simplify kernel api

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ const lst = Timecraft.Spice.et2lst( et, 499, 0, 'planetocentric' );
 import * as TimeCraft from 'timecraftjs';
 
 // load the kernel contents
-const metaKernal = await fetch( '../kernels/extras/mk/msl_chronos_v07.tm' ).then( res => res.text() );
+const metaKernel = await fetch( '../kernels/extras/mk/msl_chronos_v07.tm' ).then( res => res.text() );
 
 // parse the kernel
 const {
     KERNELS_TO_LOAD,
     PATH_VALUES,
     PATH_SYMBOLS,
-} = TimeCraft.parseMetaKernal( metaKernel );
+} = TimeCraft.parseMetaKernel( metaKernel );
 
 // process the paths to load
 const kernelPaths = KERNELS_TO_LOAD.map( path => {
@@ -170,7 +170,7 @@ This file handles detecting if running in Node or a browser, making requests for
 loadKernel( buffer : ArrayBuffer | Uint8Array, key : String = null ) : void
 ```
 
-Load the provided buffer into Spice as a kernel. The provided key can be used to unload the kernel using [unloadKernel](#unloadKernel). Throws an error if the key has already been used.
+Load the provided buffer into Spice as a kernel. The provided key can be used to unload the kernel using [unloadKernel](#unloadKernel). Throws an error if the key has already been used. Details of kernel management can be found in the [Kernel Management](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/kernel.html#Section%205%20--%20Kernel%20Management) section of the SPICE docs.
 
 #### unloadKernel
 
@@ -179,6 +179,14 @@ unloadKernel( key : String ) : void
 ```
 
 Unload the kernel that was loaded with the given key. Throws an error if a kernel has not been loaded with the given key.
+
+#### parseMetakernel
+
+```js
+parseMetakernel( contents : String ) : Object
+```
+
+Parses the contents of a metakernel `.tm` file and returns all the key value pairs in the file. This function can be used to preparse meta kernels and load the kernels referenced in the file.
 
 #### chronos
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The compiled emscripten blob includes `require( 'fs' )` which can cause Webpack 
 node: {
 
     fs: 'empty'
-    
+
 }
 ```
 
@@ -42,7 +42,7 @@ import * as TimeCraft from 'timecraftjs';
 
 // Load the kernels
 const kernelBuffers = await Promise.all( [
-    
+
     fetch( '../kernels/lsk/naif0012.tls' ).then( res => res.buffer() ),
     fetch( '../kernels/spk/de425s.bsp' ).then( res => res.buffer() ),
     fetch( '../kernels/pck/pck00008.tpc' ).then( res => res.buffer() ),
@@ -84,9 +84,9 @@ const kernelPaths = KERNELS_TO_LOAD.map( path => {
 
     let newPath = path;
     for ( let i = 0; i < PATH_VALUES.length; i ++ ) {
-    
+
         newPath = newPath.replaceAll( '$' + PATH_SYMBOLS[ i ], PATH_VALUES[ i ] );
-    
+
     }
     return newPath;
 
@@ -94,11 +94,11 @@ const kernelPaths = KERNELS_TO_LOAD.map( path => {
 
 // load the kernels in the meta kernel
 const kernelPromises = kernelPaths.map( p => {
-    
+
     return fetch( p )
         .then( res => res.buffer() )
         .then( buffer => TimeCraft.loadKernel( buffer ) );
- 
+
 } );
 
 await Promise.all( kernelPromises );
@@ -109,7 +109,7 @@ await Promise.all( kernelPromises );
 ### Using the Chronos Function
 
 ```js
-Timecraft.chronos( '617885388.6646054', '-from et -to utc -fromtype SECONDS');
+Timecraft.chronos( '617885388.6646054', '-from et -to utc -fromtype SECONDS' );
 ```
 
 ### Running the Example

--- a/README.md
+++ b/README.md
@@ -164,35 +164,21 @@ This file handles detecting if running in Node or a browser, making requests for
 
 ### Functions
 
-#### prepareFileFromBuffer
-
-```js
-prepareFileFromBuffer( path : String, buffer : ArrayBuffer | Uint8Array ) : void
-```
-
-#### removeFile
-
-```js
-removeFile( path : String ) : void
-```
-
 #### loadKernel
 
 ```js
-loadKernel( path : String ) : void
+loadKernel( buffer : ArrayBuffer | Uint8Array, key : String = null ) : void
 ```
 
-#### loadKernelFromBuffer
-
-```js
-loadKernelFromBuffer( buffer : ArrayBuffer | Uint8Array ) : void
-```
+Load the provided buffer into Spice as a kernel. The provided key can be used to unload the kernel using [unloadKernel](#unloadKernel). Throws an error if the key has already been used.
 
 #### unloadKernel
 
 ```js
-unloadKernel( path : String ) : void
+unloadKernel( key : String ) : void
 ```
+
+Unload the kernel that was loaded with the given key. Throws an error if a kernel has not been loaded with the given key.
 
 #### chronos
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ const kernelBuffers = await Promise.all( [
 // Load the kernels into Spice
 for ( let i = 0; i < kernelBuffers.length; i ++ ) {
 
-    TimeCraft.loadKernelFromBuffer( kernelBuffers[ i ] );
+    TimeCraft.loadKernel( kernelBuffers[ i ] );
 
 }
 
@@ -97,7 +97,7 @@ const kernelPromises = kernelPaths.map( p => {
     
     return fetch( p )
         .then( res => res.buffer() )
-        .then( buffer => TimeCraft.loadKernelFromBuffer( buffer ) );
+        .then( buffer => TimeCraft.loadKernel( buffer ) );
  
 } );
 

--- a/example/index.js
+++ b/example/index.js
@@ -24,7 +24,7 @@ window.Timecraft = Timecraft;
 
     buffers.forEach( buffer => {
 
-        Timecraft.loadKernelFromBuffer( buffer );
+        Timecraft.loadKernel( buffer );
 
     } );
 

--- a/example/index.js
+++ b/example/index.js
@@ -1,5 +1,5 @@
-import * as Timecraft from '../src/index.js';
-window.Timecraft = Timecraft;
+import * as TimeCraft from '../src/index.js';
+window.TimeCraft = TimeCraft;
 
 ( async function() {
 
@@ -24,7 +24,7 @@ window.Timecraft = Timecraft;
 
     buffers.forEach( buffer => {
 
-        Timecraft.loadKernel( buffer );
+        TimeCraft.loadKernel( buffer );
 
     } );
 
@@ -40,15 +40,15 @@ window.Timecraft = Timecraft;
         let utc = new Date().toISOString();
         utc = utc.slice(0, utc.length - 1);
 
-        const et = Timecraft.Spice.utc2et(utc);
+        const et = TimeCraft.Spice.utc2et(utc);
 
-        const lst = Timecraft.Spice.et2lst(et, 499, 0, 'planetocentric');
+        const lst = TimeCraft.Spice.et2lst(et, 499, 0, 'planetocentric');
 
-        const lmst = Timecraft.Spice.sce2s(-76900, et);
+        const lmst = TimeCraft.Spice.sce2s(-76900, et);
 
-        const sclk = Timecraft.Spice.sce2c(-76900, et);
+        const sclk = TimeCraft.Spice.sce2c(-76900, et);
 
-        const sunPos = Timecraft.Spice.spkpos('SUN', et, 'MSL_TOPO', 'LT+S', '-76').ptarg;
+        const sunPos = TimeCraft.Spice.spkpos('SUN', et, 'MSL_TOPO', 'LT+S', '-76').ptarg;
         let sunDir = sunPos.map(e => e / sunPos[0]);
         let sunLen = Math.sqrt(sunDir[0]**2 + sunDir[1]**2 + sunDir[2]**2);
         sunDir[0] /= sunLen;

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,7 @@
 import CSpice from './cspice.js';
 import * as Spice from './spice.js';
 import {
-    prepareFileFromBuffer,
-    removeFile,
     loadKernel,
-    loadKernelFromBuffer,
     unloadKernel,
     chronos,
     parseMetakernel,

--- a/src/index.js
+++ b/src/index.js
@@ -14,10 +14,7 @@ export {
     Spice,
     CSpice,
 
-    prepareFileFromBuffer,
-    removeFile,
     loadKernel,
-    loadKernelFromBuffer,
     unloadKernel,
     chronos,
     parseMetakernel,   

--- a/src/timecraft.js
+++ b/src/timecraft.js
@@ -53,11 +53,11 @@ export function chronos(inptim, cmdlin) {
         [cmdlin, intptr, inptim, outtim_ptr, cmdlin.length, inptim.length, 256],
     );
 
-    const ret = Module.Pointer_stringify(outtim_ptr);
+    const ret = Module.Pointer_stringify(outtim_ptr, 256);
     Module._free(outtim_ptr);
     Module._free(intptr);
 
-    return ret;
+    return ret.trim();
 }
 
 function processTokenValue(value) {

--- a/src/timecraft.js
+++ b/src/timecraft.js
@@ -74,9 +74,7 @@ export function parseMetakernel(txt) {
     // find the data section
     const matches = txt.match(/\\begindata([\w\W]+?)\\/);
     if (!matches) {
-
         return null;
-
     }
 
     // remove all newlines per variable and array values
@@ -124,4 +122,6 @@ export function parseMetakernel(txt) {
             result[name] = processTokenValue(token);
         }
     });
+
+    return result;
 }

--- a/src/timecraft.js
+++ b/src/timecraft.js
@@ -11,10 +11,14 @@ export function loadKernel(buffer, key = null) {
     if (key !== null && key in fileMap) {
         throw new Error();
     }
-    
+
+    if (buffer instanceof ArrayBuffer) {
+        buffer = new Uint8Array(buffer);
+    }
+
     const path = `_buffer_${ bufferFileCount }.bin`;
     bufferFileCount++;
-    
+
     if (key !== null) {
         fileMap[key] = path;
     }

--- a/src/timecraft.js
+++ b/src/timecraft.js
@@ -1,68 +1,40 @@
 import Module from './cspice.js';
 import * as Spice from './spice.js';
 
-let bufferFileCount = 0;
-
 const FS = Module.get_fs();
 
-function mkdirRecursive(parts) {
-    const tempParts = parts.slice();
-
-    let currPath = '';
-    while (tempParts.length) {
-        if (currPath !== '') {
-            currPath += '/';
-        }
-        currPath += tempParts.shift();
-        try {
-            FS.mkdir(currPath);
-        } catch (e) {
-            // do nothing
-        }
-    }
-}
-
-// file system manipulation
-// https://emscripten.org/docs/api_reference/Filesystem-API.html
-export function prepareFileFromBuffer(path, buffer) {
-    if (buffer instanceof ArrayBuffer) {
-        buffer = new Uint8Array(buffer);
-    }
-
-    const parts = path.split(/[\\/]/g);
-    parts.pop();
-    mkdirRecursive(parts);
-
-    FS.writeFile(path, buffer, { encoding: 'binary' });
-}
-
-export function removeFile(path) {
-    FS.unlink(path);
-}
+const fileMap = {};
+let bufferFileCount = 0;
 
 // loading kernels
-export function loadKernel(path) {
-    Spice.furnsh(path);
-}
-
-export function loadKernelFromBuffer(buffer) {
-    const path = `__buffer_files__/buffer_${ bufferFileCount }.bin`;
+export function loadKernel(buffer, key = null) {
+    if (key !== null && key in fileMap) {
+        throw new Error();
+    }
+    
+    const path = `_buffer_${ bufferFileCount }.bin`;
     bufferFileCount++;
+    fileMap[key] = path;
 
-    prepareFileFromBuffer(path, buffer);
-    loadKernel(path);
+    FS.writeFile(path, buffer, { encoding: 'binary' });
+    Spice.furnsh(path);
+    FS.unlink(path);
 }
 
 // unloading kernel
 export function unloadKernel(key) {
-    Spice.unload(key);
+    if (!(key in fileMap)) {
+        throw new Error();
+    }
+
+    Spice.unload(fileMap[key]);
+    delete fileMap[key];
 }
 
 // Chronos CLI
 // https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/ug/chronos.html
 
 export function chronos(inptim, cmdlin) {
-
     const outtim_ptr = Module._malloc(256);
     const intptr = Module._malloc(8);
 
@@ -78,7 +50,6 @@ export function chronos(inptim, cmdlin) {
     Module._free(outtim_ptr);
 
     return ret;
-
 }
 
 function processTokenValue(value) {

--- a/src/timecraft.js
+++ b/src/timecraft.js
@@ -14,7 +14,10 @@ export function loadKernel(buffer, key = null) {
     
     const path = `_buffer_${ bufferFileCount }.bin`;
     bufferFileCount++;
-    fileMap[key] = path;
+    
+    if (key !== null) {
+        fileMap[key] = path;
+    }
 
     FS.writeFile(path, buffer, { encoding: 'binary' });
     Spice.furnsh(path);


### PR DESCRIPTION
Okay last one for the weekend I promise (probably).

cc @camargo 

Relate to #7, #10

- Simplify kernel loading API to just provide `loadKernel` and `unloadKernel` with the ability to provide a key for in order to an unload a kernel.
- Remove the buffer from the virtual filesystem after it's been loaded into CSpice to free up memory.
- Update docs
- Fix chronos function overreading the results string from the pointer.
- Fix missing return from `parseMetakernel` function.

Here's the demo page from this PR to show it all works:

http://raw.githack.com/gkjohnson/timecraftjs/c528227/example/

**Future PRs**
- [ ] The output string from `chronos` does not seem to be null terminated? I wonder if this is an issue with the uses of `Pointer_stringify`?